### PR TITLE
Signature change warning - translations for REFERENCE_INVALID

### DIFF
--- a/locale/pmod.DE.ts
+++ b/locale/pmod.DE.ts
@@ -349,6 +349,14 @@ export const PMOD_DE: I18nTranslation[] = [
         key: 'pmod.nav.errors.NEW_CONNECTION_CANDIDATE.tooltip',
         value: 'Für diese Variable gibt es neue Verbindungsmöglichkeiten'
     },
+    {
+        key: 'pmod.nav.errors.REFERENCE_INVALD',
+        value: 'Workflow Signature passt nicht auf Service'
+    },
+    {
+        key: 'pmod.nav.errors.REFERENCE_INVALD.tooltip',
+        value: 'Dieser Workflow implementiert einen Service aber die Signaturen stimmen nicht überein.'
+    },
 
     // Workflow Launcher
     {

--- a/locale/pmod.EN.ts
+++ b/locale/pmod.EN.ts
@@ -347,6 +347,14 @@ export const PMOD_EN: I18nTranslation[] = [
         key: 'pmod.nav.errors.NEW_CONNECTION_CANDIDATE.tooltip',
         value: 'There is a new connection candidate for this variable'
     },
+    {
+        key: 'pmod.nav.errors.REFERENCE_INVALD',
+        value: 'Workflow signature does not match service'
+    },
+    {
+        key: 'pmod.nav.errors.REFERENCE_INVALD.tooltip',
+        value: 'This workflow is used as implementation of a service and the signatures do not match.'
+    },
 
     // Workflow Launcher
     {


### PR DESCRIPTION
If workflow is used as implementation of a service and the signatures do not match, a warning indicating this problem is created. You can't see the datatype/service in the warning, but tgere is a section under Details > Relations called 'Instance Service Reference of' showing all datatypes that use this workflow as implementation of their instance services.